### PR TITLE
Don't crash on errors in watch mode

### DIFF
--- a/src/cmds/get-schema.ts
+++ b/src/cmds/get-schema.ts
@@ -24,14 +24,21 @@ export async function handler (context: Context, argv: {endpoint: string, watch:
     const spinnerLog = msg => spinner.text = msg
 
     while (true) {
-      const isUpdated = await update(spinnerLog)
-      if (isUpdated) {
+      try {
+        const isUpdated = await update(spinnerLog)
+        if (isUpdated) {
+          spinner.stop()
+          console.log(spinner.text)
+          spinner.start()
+          spinner.text = 'Updated!'
+        } else {
+          spinner.text = 'No changes.'
+        }
+      } catch (err) {
         spinner.stop()
-        console.log(spinner.text)
+        console.error(chalk.red(err.message))
         spinner.start()
-        spinner.text = 'Updated!'
-      } else {
-        spinner.text = 'No changes.'
+        spinner.text = 'Error.'
       }
 
       spinner.text += ' Next update in 10s.'


### PR DESCRIPTION
- In non-watch mode, never catch errors.
- In watch mode, catch the whole `update` call and print the error, then retry after 10s. 

![2017-09-29 5 56 24 pm](https://user-images.githubusercontent.com/10532611/31040719-93b0d6ee-a53f-11e7-92bf-aa598c0d1dca.gif)

Fixes #21 