### PR TITLE
fix playground env var injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "express": "^4.16.2",
     "express-request-proxy": "^2.0.0",
     "graphql": "^0.11.7",
-    "graphql-config": "^1.0.8",
+    "graphql-config": "^1.0.9",
     "graphql-playground-middleware-express": "^1.3.1",
     "graphql-schema-linter": "^0.0.24",
     "inquirer": "^3.2.0",

--- a/src/cmds/playground.ts
+++ b/src/cmds/playground.ts
@@ -21,6 +21,7 @@ import expressPlayground from 'graphql-playground-middleware-express'
 import * as requestProxy from 'express-request-proxy'
 import fetch from 'node-fetch'
 import * as opn from 'opn'
+import { getUsedEnvs } from 'graphql-config'
 
 export async function handler(
   context: Context,
@@ -29,8 +30,10 @@ export async function handler(
   const localPlaygroundPath = `/Applications/GraphQL\ Playground.app/Contents/MacOS/GraphQL\ Playground`
 
   if (fs.existsSync(localPlaygroundPath)) {
+    const config = context.getConfig().config
+    const usedEnvVars = getUsedEnvs(config)
     const url = `graphql-playground://?cwd=${process.cwd()}&env=${JSON.stringify(
-      process.env,
+      usedEnvVars,
     )}`
     opn(url, { wait: false })
   } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2082,9 +2082,9 @@ graphql-config@^1.0.0:
     minimatch "^3.0.4"
     rimraf "^2.6.1"
 
-graphql-config@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-1.0.8.tgz#6dd1cd76ff6fbb01662704f8bddc403f6b0c24d9"
+graphql-config@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-1.0.9.tgz#8fa416a7c2bdb8f62f441324775dd3ff8a266652"
   dependencies:
     graphql "^0.11.7"
     graphql-request "^1.4.0"


### PR DESCRIPTION
Instead of sending all environment variables, with this PR, only the used ones are filtered.
Otherwise, the url limit of 2083 chars can be easily reached.